### PR TITLE
Pass HTML comments through unmodified

### DIFF
--- a/lib/markdown_formatter/renderer.ex
+++ b/lib/markdown_formatter/renderer.ex
@@ -164,6 +164,10 @@ defmodule MarkdownFormatter.Renderer do
   defp render({tag, [], [contents], %{verbatim: true}}, doc, _opts) when is_binary(contents),
     do: push(doc, ["<#{tag}>\n#{contents}\n</#{tag}>"])
 
+  # comments
+  defp render({:comment, [], contents, %{comment: true}}, doc, opts),
+    do: add_section(doc, ["<!--", Enum.join(contents, "\n"), "-->"], opts)
+
   # text node
   defp render([text], @empty_queue, opts) when is_binary(text), do: text |> reformat(opts)
   defp render(text, @empty_queue, opts) when is_binary(text), do: text |> reformat(opts)

--- a/test/markdown_formatter/renderer_test.exs
+++ b/test/markdown_formatter/renderer_test.exs
@@ -217,6 +217,27 @@ defmodule MarkdownFormatter.RendererTest do
       """)
     end
 
+    test "renders html comments" do
+      """
+      <!--
+        SPDX-FileCopyrightText: Someone
+        SPDX-License-Identifier: Apache-2.0
+      -->
+
+      # header
+      """
+      |> parse!()
+      |> Renderer.to_markdown()
+      |> assert_eq("""
+      <!--
+        SPDX-FileCopyrightText: Someone
+        SPDX-License-Identifier: Apache-2.0
+      -->
+
+      # header
+      """)
+    end
+
     test "renders collapsible items" do
       """
       <details>


### PR DESCRIPTION
This fixes a crash when processing Markdown files with SPDX license and
copyright headers, but more generally, it allows any HTML comments to
pass through unmodified.
